### PR TITLE
Added feedback after each roughly 100,000 file system objects.

### DIFF
--- a/dircnt.c
+++ b/dircnt.c
@@ -23,10 +23,15 @@
 #include <sys/stat.h>
 
 #if defined(WIN32) || defined(_WIN32)
-#define PATH_SEPARATOR '\\' 
+#define PATH_SEPARATOR '\\'
 #else
 #define PATH_SEPARATOR '/'
 #endif
+
+// FEEDBACK_INTERVAL 0 turns off feedback.
+// Low feedback intervals will impact performance. Suggest 0 or > 1000.
+// Feedback is intentionally inexact (toward code simplicity), occurring on or after each feedback interval.
+#define FEEDBACK_INTERVAL 10000
 
 /* A custom structure to hold separate file and directory counts */
 struct filecount {
@@ -95,10 +100,9 @@ void count(char *path, struct filecount *counts) {
             counts->feedbackLimit++;
         }
 
-        // For very large counts, give the user intermittent feedback.
-        // Because we recurse on directories, we may not land here on any specific number.
-        if(counts->feedbackLimit > 99999) {
-            printf("%ld files in %ld dirs as of path: %s\n", counts->files, counts->dirs, path);
+        if(FEEDBACK_INTERVAL && counts->feedbackLimit > FEEDBACK_INTERVAL) {
+            printf("In progress: %ld files and %ld directories so far.\r", counts->files, counts->dirs);
+            fflush(stdout);
             counts->feedbackLimit = 0;
         }
     }
@@ -134,7 +138,7 @@ int main(int argc, char *argv[]) {
 
     /* If we found nothing, this is probably an error which has already been printed */
     if(0 < counts.files || 0 < counts.dirs) {
-        printf("%s contains %ld files and %ld directories\n", dir, counts.files, counts.dirs);
+        printf("Complete: %s contains %ld files and %ld directories\n", dir, counts.files, counts.dirs);
     }
 
     return 0;


### PR DESCRIPTION
Added a separate count for tracking when to give feedback. Used this method instead of modulus operator in attempt to stay true to the original intent of this being an extremely fast implementation. Yet needed some indication that the program is not stalled during count of entire drives, etc.

I notice my IDE removed some line ending whitespace, making the default diffing at github difficult.  To ignore whitespace changes during review at github, add ?w=1 to the URL. For example: 
   https://github.com/ChristopherSchultz/fast-file-count/compare/master...HumanJHawkins:master?w=1

Thanks for considering this change.
Jeff

